### PR TITLE
feat: Upgrade k6 to v0.38.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-stomp/stomp/v3 v3.0.4
 	github.com/gorilla/websocket v1.5.0
 	github.com/tidwall/gjson v1.14.0
-	go.k6.io/k6 v0.37.0
+	go.k6.io/k6 v0.38.3
 )
 
 require (

--- a/stats.go
+++ b/stats.go
@@ -5,39 +5,40 @@ import (
 	"time"
 
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/lib/metrics"
-	"go.k6.io/k6/stats"
+	"go.k6.io/k6/metrics"
 )
 
 var (
-	dataSent     = stats.New(metrics.DataSentName, stats.Counter, stats.Data)
-	dataReceived = stats.New(metrics.DataReceivedName, stats.Counter, stats.Data)
+	registry    = metrics.NewRegistry()
+	dataSent, _ = registry.NewMetric(metrics.DataSentName, metrics.Counter, metrics.Data)
 
-	sendMessage       = stats.New("stomp_send_count", stats.Counter)
-	sendMessageTiming = stats.New("stomp_send_time", stats.Trend, stats.Time)
-	sendMessageErrors = stats.New("stomp_send_error_count", stats.Counter)
+	dataReceived, _ = registry.NewMetric(metrics.DataReceivedName, metrics.Counter, metrics.Data)
 
-	readMessage       = stats.New("stomp_read_count", stats.Counter)
-	readMessageTiming = stats.New("stomp_read_time", stats.Trend, stats.Time)
-	readMessageErrors = stats.New("stomp._read_error_count", stats.Counter)
+	sendMessage, _       = registry.NewMetric("stomp_send_count", metrics.Counter)
+	sendMessageTiming, _ = registry.NewMetric("stomp_send_time", metrics.Trend, metrics.Time)
+	sendMessageErrors, _ = registry.NewMetric("stomp_send_error_count", metrics.Counter)
 
-	ackMessage       = stats.New("stomp_ack_count", stats.Counter)
-	ackMessageErrors = stats.New("stomp_ack_error_count", stats.Counter)
+	readMessage, _       = registry.NewMetric("stomp_read_count", metrics.Counter)
+	readMessageTiming, _ = registry.NewMetric("stomp_read_time", metrics.Trend, metrics.Time)
+	readMessageErrors, _ = registry.NewMetric("stomp._read_error_count", metrics.Counter)
 
-	nackMessage       = stats.New("stomp_nack_count", stats.Counter)
-	nackMessageErrors = stats.New("stomp_nack_error_count", stats.Counter)
+	ackMessage, _       = registry.NewMetric("stomp_ack_count", metrics.Counter)
+	ackMessageErrors, _ = registry.NewMetric("stomp_ack_error_count", metrics.Counter)
+
+	nackMessage, _       = registry.NewMetric("stomp_nack_count", metrics.Counter)
+	nackMessageErrors, _ = registry.NewMetric("stomp_nack_error_count", metrics.Counter)
 )
 
-func reportStats(vu modules.VU, metric *stats.Metric, tags map[string]string, now time.Time, value float64) {
+func reportStats(vu modules.VU, metric *metrics.Metric, tags map[string]string, now time.Time, value float64) {
 	state := vu.State()
 	if state == nil {
 		return
 	}
 
-	stats.PushIfNotDone(vu.Context(), state.Samples, stats.Sample{
+	metrics.PushIfNotDone(vu.Context(), state.Samples, metrics.Sample{
 		Time:   now,
 		Metric: metric,
-		Tags:   stats.IntoSampleTags(&tags),
+		Tags:   metrics.IntoSampleTags(&tags),
 		Value:  value,
 	})
 }

--- a/stomp.go
+++ b/stomp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"go.k6.io/k6/metrics"
 	"io"
 	"net"
 	"time"
@@ -13,7 +14,6 @@ import (
 
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/stats"
 )
 
 // Register the extension on module initialization, available to
@@ -217,7 +217,7 @@ func (c *Client) Send(destination, contentType string, body []byte, opts *SendOp
 	startedAt := time.Now()
 	defer func() {
 		now := time.Now()
-		reportStats(c.vu, sendMessageTiming, nil, now, stats.D(now.Sub(startedAt)))
+		reportStats(c.vu, sendMessageTiming, nil, now, metrics.D(now.Sub(startedAt)))
 		if err != nil {
 			reportStats(c.vu, sendMessageErrors, nil, now, 1)
 		} else {

--- a/subscription.go
+++ b/subscription.go
@@ -1,12 +1,12 @@
 package stomp
 
 import (
+	"go.k6.io/k6/metrics"
 	"time"
 
 	"github.com/go-stomp/stomp/v3"
 	"github.com/go-stomp/stomp/v3/frame"
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/stats"
 )
 
 type Subscription struct {
@@ -69,7 +69,7 @@ func (s *Subscription) Read() (msg *Message, err error) {
 	startedAt := time.Now()
 	defer func() {
 		now := time.Now()
-		reportStats(s.vu, readMessageTiming, nil, now, stats.D(now.Sub(startedAt)))
+		reportStats(s.vu, readMessageTiming, nil, now, metrics.D(now.Sub(startedAt)))
 		if err != nil {
 			reportStats(s.vu, readMessageErrors, nil, now, 1)
 		} else {

--- a/transaction.go
+++ b/transaction.go
@@ -1,12 +1,12 @@
 package stomp
 
 import (
+	"go.k6.io/k6/metrics"
 	"time"
 
 	"github.com/go-stomp/stomp/v3"
 	"github.com/go-stomp/stomp/v3/frame"
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/stats"
 )
 
 type Transaction struct {
@@ -18,7 +18,7 @@ func (tx *Transaction) Send(destination, contentType string, body []byte, opts *
 	startedAt := time.Now()
 	defer func() {
 		now := time.Now()
-		reportStats(tx.vu, sendMessageTiming, nil, now, stats.D(now.Sub(startedAt)))
+		reportStats(tx.vu, sendMessageTiming, nil, now, metrics.D(now.Sub(startedAt)))
 		if err != nil {
 			reportStats(tx.vu, sendMessageErrors, nil, now, 1)
 		} else {


### PR DESCRIPTION
Upgrade to [v0.38.0](https://github.com/grafana/k6/releases/tag/v0.38.0) and resolve breaking changes

The Go types in the stats package were moved to the metrics package [#2433](https://github.com/grafana/k6/pull/2433)
For convenience and to facilitate further developments, the types and functionalities that used to live in k6's stats package have been moved to the metrics package. The stats package is, as of v0.38.0, removed in favor of the metrics package. Besides, [#2442](https://github.com/grafana/k6/pull/2442) removed the stats.New function in favor of initializing new metric via a register.NewMetric call instead.